### PR TITLE
Make renderer work with ServiceStack 4.0.30

### DIFF
--- a/src/FluentEmail.Markdown.Tests/FluentEmail.Markdown.Tests.csproj
+++ b/src/FluentEmail.Markdown.Tests/FluentEmail.Markdown.Tests.csproj
@@ -35,24 +35,25 @@
   <ItemGroup>
     <Reference Include="FluentEmail, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\fluent-email.1.2.2\lib\net40\FluentEmail.dll</HintPath>
+      <HintPath>..\packages\fluent-email.1.3.0\lib\net40\FluentEmail.dll</HintPath>
+    </Reference>
+    <Reference Include="RazorEngine">
+      <HintPath>..\packages\RazorEngine.3.2.0\lib\net40\RazorEngine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\RazorMachine.2.5\lib\net40\System.Web.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20715.0\lib\net40\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Xipton.Razor">
-      <HintPath>..\packages\RazorMachine.2.5\lib\net40\Xipton.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit">
-      <HintPath>..\packages\xunit.1.9.1\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -62,7 +63,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <Content Include="razormachine.readme.txt" />
     <Content Include="test.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/FluentEmail.Markdown.Tests/packages.config
+++ b/src/FluentEmail.Markdown.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="fluent-email" version="1.2.2" targetFramework="net45" />
-  <package id="RazorMachine" version="2.5" targetFramework="net45" />
-  <package id="xunit" version="1.9.1" targetFramework="net45" />
+  <package id="fluent-email" version="1.3.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.20715.0" targetFramework="net45" />
+  <package id="RazorEngine" version="3.2.0" targetFramework="net45" />
+  <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/FluentEmail.Markdown/FluentEmail.Markdown.csproj
+++ b/src/FluentEmail.Markdown/FluentEmail.Markdown.csproj
@@ -36,54 +36,41 @@
   <ItemGroup>
     <Reference Include="FluentEmail, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\fluent-email.1.2.2\lib\net40\FluentEmail.dll</HintPath>
+      <HintPath>..\packages\fluent-email.1.3.0\lib\net40\FluentEmail.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack, Version=3.9.35.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.3.9.35\lib\net35\ServiceStack.dll</HintPath>
+    <Reference Include="RazorEngine">
+      <HintPath>..\packages\RazorEngine.3.2.0\lib\net40\RazorEngine.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=3.9.35.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack, Version=4.0.30.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.35\lib\net35\ServiceStack.Common.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.4.0.30\lib\net40\ServiceStack.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=3.9.35.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.35\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Client">
+      <HintPath>..\packages\ServiceStack.Client.4.0.30\lib\net40\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.OrmLite, Version=3.9.35.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Common, Version=4.0.30.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.OrmLite.SqlServer.3.9.35\lib\ServiceStack.OrmLite.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.4.0.30\lib\net40\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.OrmLite.SqlServer, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.OrmLite.SqlServer.3.9.35\lib\ServiceStack.OrmLite.SqlServer.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Interfaces.4.0.30\lib\portable-wp80+sl5+net40+win8+monotouch+monoandroid\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Redis, Version=3.9.35.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Text, Version=4.0.30.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Redis.3.9.35\lib\net35\ServiceStack.Redis.dll</HintPath>
-    </Reference>
-    <Reference Include="ServiceStack.ServiceInterface, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.3.9.35\lib\net35\ServiceStack.ServiceInterface.dll</HintPath>
-    </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.35.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Text.3.9.35\lib\net35\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.4.0.30\lib\net40\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\RazorMachine.2.5\lib\net40\System.Web.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20715.0\lib\net40\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Xipton.Razor">
-      <HintPath>..\packages\RazorMachine.2.5\lib\net40\Xipton.Razor.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MarkdownRenderer.cs" />
@@ -92,9 +79,6 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="Properties\FluentEmail.Markdown.nuspec" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="razormachine.readme.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/src/FluentEmail.Markdown/MarkdownRenderer.cs
+++ b/src/FluentEmail.Markdown/MarkdownRenderer.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using ServiceStack.WebHost.Endpoints.Formats;
-using ServiceStack.WebHost.Endpoints.Support.Markdown;
+using ServiceStack.Formats;
+using ServiceStack.Support.Markdown;
 
 namespace FluentEmail.Markdown
 {

--- a/src/FluentEmail.Markdown/packages.config
+++ b/src/FluentEmail.Markdown/packages.config
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="fluent-email" version="1.2.2" targetFramework="net40" />
-  <package id="RazorMachine" version="2.5" targetFramework="net40" />
-  <package id="ServiceStack" version="3.9.35" targetFramework="net40" />
-  <package id="ServiceStack.Common" version="3.9.35" targetFramework="net40" />
-  <package id="ServiceStack.OrmLite.SqlServer" version="3.9.35" targetFramework="net40" />
-  <package id="ServiceStack.Redis" version="3.9.35" targetFramework="net40" />
-  <package id="ServiceStack.Text" version="3.9.35" targetFramework="net40" />
+  <package id="fluent-email" version="1.3.0" targetFramework="net40" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.20715.0" targetFramework="net40" />
+  <package id="RazorEngine" version="3.2.0" targetFramework="net40" />
+  <package id="ServiceStack" version="4.0.30" targetFramework="net40" />
+  <package id="ServiceStack.Client" version="4.0.30" targetFramework="net40" />
+  <package id="ServiceStack.Common" version="4.0.30" targetFramework="net40" />
+  <package id="ServiceStack.Interfaces" version="4.0.30" targetFramework="net40" />
+  <package id="ServiceStack.Text" version="4.0.30" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Classes in the ServiceStack assembly moved to other namespaces. Change
the namespaces to make FluentEmail.Markdown work with version 4.0.30 of
ServiceStack
